### PR TITLE
Fix a11y hover color

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,7 +3,8 @@ image: drupalpod/drupalpod-gitpod-base:20211116-ready-made-envs
 # ddev and composer are running as part of the prebuild
 # when starting a workspace all docker images are ready
 tasks:
-  - init: |
+  - name: Main Terminal
+    init: |
       ddev debug download-images
       .gitpod/ddev-in-gitpod-setup.sh
       .gitpod/project-setup.sh
@@ -11,6 +12,10 @@ tasks:
       .gitpod/ddev-in-gitpod-setup.sh
       ddev start
       gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
+  - name: Theme sass-watch
+    openMode: split-right
+    command: |
+      cd "$GITPOD_REPO_ROOT"/web/themes/pubsub && yarn gulp sass:watch
 
 # VScode xdebug extension
 vscode:

--- a/.gitpod/project-setup.sh
+++ b/.gitpod/project-setup.sh
@@ -16,4 +16,5 @@ fi
 
 cd "$GITPOD_REPO_ROOT" && ddev drush updb -y
 cd "$GITPOD_REPO_ROOT" && ddev drush cim -y
+cd "$GITPOD_REPO_ROOT"/web/themes/pubsub && yarn && yarn gulp sass
 cd "$GITPOD_REPO_ROOT" && ddev drush cr

--- a/web/themes/pubsub/css/base/base.css
+++ b/web/themes/pubsub/css/base/base.css
@@ -43,7 +43,7 @@ a {
   transition: color 0.2s;
 }
 a:hover {
-  color: var(--color--ocean-55);
+  color: var(--color--ocean-37);
 }
 a:focus {
   outline: solid 2px var(--focus-ring-color);

--- a/web/themes/pubsub/css/base/css-variables.css
+++ b/web/themes/pubsub/css/base/css-variables.css
@@ -41,6 +41,7 @@
   --color--ocean-10: hsla(200, 59%, 13%, 1);
   --color--ocean-15: hsla(201, 100%, 16%, 1);
   --color--ocean-30: hsla(201, 100%, 29%, 1);
+  --color--ocean-37: hsla(201, 100%, 37%, 1);
   --color--ocean-40: hsla(202, 100%, 42%, 1);
   --color--ocean-55: hsla(201, 100%, 55%, 1);
   --color--sun-30: hsla(18, 95%, 30%, 1);

--- a/web/themes/pubsub/sass/base/base.scss
+++ b/web/themes/pubsub/sass/base/base.scss
@@ -46,7 +46,7 @@ a {
   transition: color 0.2s;
 
   &:hover {
-    color: var(--color--ocean-55);
+    color: var(--color--ocean-37);
   }
 
   &:focus {

--- a/web/themes/pubsub/sass/base/css-variables.scss
+++ b/web/themes/pubsub/sass/base/css-variables.scss
@@ -51,6 +51,7 @@
   --color--ocean-10: hsla(200, 59%, 13%, 1);
   --color--ocean-15: hsla(201, 100%, 16%, 1);
   --color--ocean-30: hsla(201, 100%, 29%, 1);
+  --color--ocean-37: hsla(201, 100%, 37%, 1); // 4.59 against white.
   --color--ocean-40: hsla(202, 100%, 42%, 1);
   --color--ocean-55: hsla(201, 100%, 55%, 1);
 


### PR DESCRIPTION
## Issue:
When hovering over menu items in the main menu, the color contrast does not pass AA.

## Fix:
replacing `--color--ocean-55` with `--color--ocean-37`, which is the closest color that pass AA.

![image](https://user-images.githubusercontent.com/22901/144362644-34df128f-a751-4a40-88b6-db1baa04dbce.png)

## Testing:
* Click on the Gitpod button below
* When preview website open, hover above main menu items
* Confirm that the new color is set (`--color--ocean-37`), and that it passes AA.
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

